### PR TITLE
feat: add option to rename release tool visited files

### DIFF
--- a/src/release_tool.rs
+++ b/src/release_tool.rs
@@ -1,15 +1,57 @@
 ﻿use crate::extend::{read_blake3, Blake3Path};
 mod extend;
+#[allow(dead_code)]
 mod global;
 mod release_definition;
 
 use crate::global::UPDATE_INFO_ASSET_NAME;
 use crate::release_definition::{UpdateArchiveDto, UpdateDataDto, UpdateFileDto};
+use clap::Parser;
+use std::fs;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use std::{env, fs};
 use zip::ZipArchive;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Rename files to technical names so users are not tempted to download them
+    /// as they are only meant for the launcher
+    #[arg(long = "rename-files")]
+    rename_files: bool,
+
+    /// The folder to create an update.json for.
+    /// The resulting `update.json` file is placed in that folder as well
+    path: PathBuf,
+}
+
+fn rename_update_file(
+    file: &Path,
+    keep_extension: bool,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let file_name = file
+        .file_name()
+        .ok_or("File must have a name")?
+        .to_str()
+        .ok_or("Failed to convert file name to str")?;
+
+    let updated_file_name = if keep_extension {
+        String::from(file_name)
+    } else {
+        file_name.replace(".", "_")
+    };
+
+    let renamed_file_name = format!("__launcher_{updated_file_name}");
+    let renamed_file_full_path = file
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(&renamed_file_name);
+
+    fs::rename(file, &renamed_file_full_path)?;
+
+    Ok(renamed_file_full_path)
+}
 
 fn visit_archive(
     file: &Path,
@@ -55,8 +97,8 @@ fn visit_archive(
 }
 
 fn visit_dir_file(
+    args: &Args,
     file: &Path,
-    file_name: String,
     relative_path: String,
     data: &mut UpdateDataDto,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -75,8 +117,20 @@ fn visit_dir_file(
         .map(|extension| extension.eq_ignore_ascii_case("zip"))
         .unwrap_or(false);
 
+    let update_file_path = if args.rename_files {
+        rename_update_file(file, is_zip)?
+    } else {
+        PathBuf::from(file)
+    };
+    let file_name = update_file_path
+        .file_name()
+        .ok_or("File must have a name")?
+        .to_str()
+        .ok_or("Failed to convert file name to str")?
+        .to_string();
+
     if is_zip {
-        visit_archive(file, &file_name, &relative_path, data)?;
+        visit_archive(&update_file_path, &file_name, &relative_path, data)?;
         data.archives.push(UpdateArchiveDto {
             blake3,
             size,
@@ -96,6 +150,7 @@ fn visit_dir_file(
 }
 
 fn visit_dir(
+    args: &Args,
     dir: &Path,
     relative_path: &str,
     data: &mut UpdateDataDto,
@@ -122,42 +177,40 @@ fn visit_dir(
         };
 
         if file_type.is_file() {
-            visit_dir_file(&file_path, file_name, file_relative_path, data)?;
+            visit_dir_file(args, &file_path, file_relative_path, data)?;
         } else if file_type.is_dir() {
-            visit_dir(&file_path, &file_relative_path, data)?;
+            visit_dir(args, &file_path, &file_relative_path, data)?;
         }
     }
 
     Ok(())
 }
 
-fn build_release_definition(dir: &Path) -> Result<UpdateDataDto, Box<dyn std::error::Error>> {
+fn build_release_definition(
+    args: &Args,
+    dir: &Path,
+) -> Result<UpdateDataDto, Box<dyn std::error::Error>> {
     let mut data = UpdateDataDto {
         archives: vec![],
         files: vec![],
     };
 
-    visit_dir(dir, "", &mut data)?;
+    visit_dir(args, dir, "", &mut data)?;
 
     Ok(data)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Vec<String> = env::args().collect();
+    let args = Args::parse();
 
-    if args.len() < 2 {
-        eprintln!("Usage: <path>");
-        return Ok(());
-    }
-
-    let path_str = args[1].as_str();
-    let path = PathBuf::from(path_str);
+    let path = &args.path;
+    let path_str = path.to_str().ok_or("Failed to convert path to str")?;
 
     if path.metadata().map(|m| !m.is_dir()).unwrap_or(true) {
         return Err(Box::from(format!("Must be a directory: {path_str}")));
     }
 
-    let update_data = build_release_definition(&path)?;
+    let update_data = build_release_definition(&args, path)?;
     let update_data_str = serde_json::to_string(&update_data)?;
 
     let definition_file = path.join(UPDATE_INFO_ASSET_NAME);


### PR DESCRIPTION
Make users less likely to download the launcher files by renaming them to `__launcher_<previousFileName>`.

<img width="266" height="254" alt="2025-09-25_21-16-15" src="https://github.com/user-attachments/assets/7b0f4ec9-f7be-472b-aaf8-7ca226e8a0c7" />
