### PR TITLE
fix: always add an extension for release tool renames

### DIFF
--- a/src/release_tool.rs
+++ b/src/release_tool.rs
@@ -39,7 +39,7 @@ fn rename_update_file(
     let updated_file_name = if keep_extension {
         String::from(file_name)
     } else {
-        file_name.replace(".", "_")
+        format!("{}.bin", file_name.replace(".", "_"))
     };
 
     let renamed_file_name = format!("__launcher_{updated_file_name}");


### PR DESCRIPTION
Not having an extension makes the rawfile release not work anymore unfortunately, see https://github.com/iw4x/iw4x-rawfiles/pull/72