### PR TITLE
Reconsider deprecation of current directory execution

### DIFF
--- a/launcher/launcher/cache/cache-database.hxx
+++ b/launcher/launcher/cache/cache-database.hxx
@@ -159,6 +159,21 @@ namespace launcher
     std::vector<component_version>
     versions () const;
 
+    // User settings.
+    //
+
+    std::optional<user_setting>
+    setting (const string_type& key) const;
+
+    string_type
+    setting_value (const string_type& key) const;
+
+    void
+    setting (const string_type& key, const string_type& value);
+
+    void
+    erase_setting (const string_type& key);
+
     // Transaction wrappers.
     //
 

--- a/launcher/launcher/cache/cache-types.hxx
+++ b/launcher/launcher/cache/cache-types.hxx
@@ -216,6 +216,72 @@ namespace launcher
     std::int64_t installed_at_;
   };
 
+  // Persist user preferences (e.g., install paths, Steam prompt decisions).
+  //
+  // We use a simple key-value store approach here. While it's slightly less
+  // structured than individual columns, it allows us to add new settings
+  // without migrating the schema every time we add a toggle.
+  //
+  #pragma db object table("user_settings")
+  class user_setting
+  {
+  public:
+    user_setting () = default;
+
+    // Use direct initialization for efficiency.
+    //
+    user_setting (std::string k, std::string v)
+      : key_ (std::move (k)),
+        val_ (std::move (v))
+    {
+    }
+
+    const std::string&
+    key () const noexcept { return key_; }
+
+    const std::string&
+    val () const noexcept { return val_; }
+
+    void
+    val (std::string v) { val_ = std::move (v); }
+
+  private:
+    friend class odb::access;
+
+    #pragma db id
+    std::string key_;
+
+    // Shorten to val_ to keep the implementation lines compact.
+    //
+    std::string val_;
+  };
+
+  // Map logical setting names to their database keys.
+  //
+  // Note that settings that need to be scoped per-installation (to support
+  // multiple MW2 installations each with their own launcher) take a scope
+  // parameter which is typically the digest of the launcher's current
+  // directory.
+  //
+  namespace setting_keys
+  {
+    // Format as "install_path.<scope>".
+    //
+    inline std::string
+    inst_path (const std::string& s)
+    {
+      return "install_path." + s;
+    }
+
+    // Format as "steam_prompt.<scope>.<digest>".
+    //
+    inline std::string
+    steam_prompt (const std::string& s, const std::string& d)
+    {
+      return "steam_prompt." + s + "." + d;
+    }
+  }
+
   // Refer to the legacy cache implementation for context.
   //
 

--- a/launcher/launcher/launcher.cli
+++ b/launcher/launcher/launcher.cli
@@ -16,6 +16,11 @@ namespace launcher
       "Show version information and exit."
     };
 
+    bool --wipe-settings
+    {
+      "Clear the global settings cache."
+    };
+
     // build2 metadata export protocol.
     //
     bool --build2-metadata

--- a/launcher/launcher/pregenerated/launcher/cache/cache-types-odb.cxx
+++ b/launcher/launcher/pregenerated/launcher/cache/cache-types-odb.cxx
@@ -1508,6 +1508,641 @@ namespace odb
 
     return st.execute ();
   }
+
+  // user_setting
+  //
+
+  struct access::object_traits_impl< ::launcher::user_setting, id_sqlite >::extra_statement_cache_type
+  {
+    extra_statement_cache_type (
+      sqlite::connection&,
+      image_type&,
+      id_image_type&,
+      sqlite::binding&,
+      sqlite::binding&)
+    {
+    }
+  };
+
+  access::object_traits_impl< ::launcher::user_setting, id_sqlite >::id_type
+  access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  id (const image_type& i)
+  {
+    sqlite::database* db (0);
+    ODB_POTENTIALLY_UNUSED (db);
+
+    id_type id;
+    {
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_value (
+        id,
+        i.key_value,
+        i.key_size,
+        i.key_null);
+    }
+
+    return id;
+  }
+
+  bool access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  grow (image_type& i,
+        bool* t)
+  {
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (t);
+
+    bool grew (false);
+
+    // key_
+    //
+    if (t[0UL])
+    {
+      i.key_value.capacity (i.key_size);
+      grew = true;
+    }
+
+    // val_
+    //
+    if (t[1UL])
+    {
+      i.val_value.capacity (i.val_size);
+      grew = true;
+    }
+
+    return grew;
+  }
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  bind (sqlite::bind* b,
+        image_type& i,
+        sqlite::statement_kind sk)
+  {
+    ODB_POTENTIALLY_UNUSED (sk);
+
+    using namespace sqlite;
+
+    std::size_t n (0);
+
+    // key_
+    //
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::image_traits<
+        ::std::string,
+        sqlite::id_text>::bind_value;
+      b[n].buffer = i.key_value.data ();
+      b[n].size = &i.key_size;
+      b[n].capacity = i.key_value.capacity ();
+      b[n].is_null = &i.key_null;
+      n++;
+    }
+
+    // val_
+    //
+    b[n].type = sqlite::image_traits<
+      ::std::string,
+      sqlite::id_text>::bind_value;
+    b[n].buffer = i.val_value.data ();
+    b[n].size = &i.val_size;
+    b[n].capacity = i.val_value.capacity ();
+    b[n].is_null = &i.val_null;
+    n++;
+  }
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  bind (sqlite::bind* b, id_image_type& i)
+  {
+    std::size_t n (0);
+    b[n].type = sqlite::image_traits<
+      ::std::string,
+      sqlite::id_text>::bind_value;
+    b[n].buffer = i.id_value.data ();
+    b[n].size = &i.id_size;
+    b[n].capacity = i.id_value.capacity ();
+    b[n].is_null = &i.id_null;
+  }
+
+  bool access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  init (image_type& i,
+        const object_type& o,
+        sqlite::statement_kind sk)
+  {
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (o);
+    ODB_POTENTIALLY_UNUSED (sk);
+
+    using namespace sqlite;
+
+    bool grew (false);
+
+    // key_
+    //
+    if (sk == statement_insert)
+    {
+      ::std::string const& v =
+        o.key_;
+
+      bool is_null (false);
+      std::size_t cap (i.key_value.capacity ());
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_image (
+        i.key_value,
+        i.key_size,
+        is_null,
+        v);
+      i.key_null = is_null;
+      grew = grew || (cap != i.key_value.capacity ());
+    }
+
+    // val_
+    //
+    {
+      ::std::string const& v =
+        o.val_;
+
+      bool is_null (false);
+      std::size_t cap (i.val_value.capacity ());
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_image (
+        i.val_value,
+        i.val_size,
+        is_null,
+        v);
+      i.val_null = is_null;
+      grew = grew || (cap != i.val_value.capacity ());
+    }
+
+    return grew;
+  }
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  init (object_type& o,
+        const image_type& i,
+        database* db)
+  {
+    ODB_POTENTIALLY_UNUSED (o);
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (db);
+
+    // key_
+    //
+    {
+      ::std::string& v =
+        o.key_;
+
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_value (
+        v,
+        i.key_value,
+        i.key_size,
+        i.key_null);
+    }
+
+    // val_
+    //
+    {
+      ::std::string& v =
+        o.val_;
+
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_value (
+        v,
+        i.val_value,
+        i.val_size,
+        i.val_null);
+    }
+  }
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  init (id_image_type& i, const id_type& id)
+  {
+    bool grew (false);
+    {
+      bool is_null (false);
+      std::size_t cap (i.id_value.capacity ());
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_image (
+        i.id_value,
+        i.id_size,
+        is_null,
+        id);
+      i.id_null = is_null;
+      grew = grew || (cap != i.id_value.capacity ());
+    }
+
+    if (grew)
+      i.version++;
+  }
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::persist_statement[] =
+  "INSERT INTO \"user_settings\" "
+  "(\"key\", "
+  "\"val\") "
+  "VALUES "
+  "(?, ?)";
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::find_statement[] =
+  "SELECT "
+  "\"user_settings\".\"key\", "
+  "\"user_settings\".\"val\" "
+  "FROM \"user_settings\" "
+  "WHERE \"user_settings\".\"key\"=?";
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::update_statement[] =
+  "UPDATE \"user_settings\" "
+  "SET "
+  "\"val\"=? "
+  "WHERE \"key\"=?";
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::erase_statement[] =
+  "DELETE FROM \"user_settings\" "
+  "WHERE \"key\"=?";
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::query_statement[] =
+  "SELECT "
+  "\"user_settings\".\"key\", "
+  "\"user_settings\".\"val\" "
+  "FROM \"user_settings\"";
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::erase_query_statement[] =
+  "DELETE FROM \"user_settings\"";
+
+  const char access::object_traits_impl< ::launcher::user_setting, id_sqlite >::table_name[] =
+  "\"user_settings\"";
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  persist (database& db, const object_type& obj)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    callback (db,
+              obj,
+              callback_event::pre_persist);
+
+    image_type& im (sts.image ());
+    binding& imb (sts.insert_image_binding ());
+
+    if (init (im, obj, statement_insert))
+      im.version++;
+
+    if (im.version != sts.insert_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, im, statement_insert);
+      sts.insert_image_version (im.version);
+      imb.version++;
+    }
+
+    insert_statement& st (sts.persist_statement ());
+    if (!st.execute ())
+      throw object_already_persistent ();
+
+    callback (db,
+              obj,
+              callback_event::post_persist);
+  }
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  update (database& db, const object_type& obj)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+
+    using namespace sqlite;
+    using sqlite::update_statement;
+
+    callback (db, obj, callback_event::pre_update);
+
+    sqlite::transaction& tr (sqlite::transaction::current ());
+    sqlite::connection& conn (tr.connection (db));
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    id_image_type& idi (sts.id_image ());
+    init (idi, id (obj));
+
+    image_type& im (sts.image ());
+    if (init (im, obj, statement_update))
+      im.version++;
+
+    bool u (false);
+    binding& imb (sts.update_image_binding ());
+    if (im.version != sts.update_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, im, statement_update);
+      sts.update_image_version (im.version);
+      imb.version++;
+      u = true;
+    }
+
+    binding& idb (sts.id_image_binding ());
+    if (idi.version != sts.update_id_image_version () ||
+        idb.version == 0)
+    {
+      if (idi.version != sts.id_image_version () ||
+          idb.version == 0)
+      {
+        bind (idb.bind, idi);
+        sts.id_image_version (idi.version);
+        idb.version++;
+      }
+
+      sts.update_id_image_version (idi.version);
+
+      if (!u)
+        imb.version++;
+    }
+
+    update_statement& st (sts.update_statement ());
+    if (st.execute () == 0)
+      throw object_not_persistent ();
+
+    callback (db, obj, callback_event::post_update);
+    pointer_cache_traits::update (db, obj);
+  }
+
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  erase (database& db, const id_type& id)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    id_image_type& i (sts.id_image ());
+    init (i, id);
+
+    binding& idb (sts.id_image_binding ());
+    if (i.version != sts.id_image_version () || idb.version == 0)
+    {
+      bind (idb.bind, i);
+      sts.id_image_version (i.version);
+      idb.version++;
+    }
+
+    if (sts.erase_statement ().execute () != 1)
+      throw object_not_persistent ();
+
+    pointer_cache_traits::erase (db, id);
+  }
+
+  access::object_traits_impl< ::launcher::user_setting, id_sqlite >::pointer_type
+  access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  find (database& db, const id_type& id)
+  {
+    using namespace sqlite;
+
+    {
+      pointer_type p (pointer_cache_traits::find (db, id));
+
+      if (!pointer_traits::null_ptr (p))
+        return p;
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    statements_type::auto_lock l (sts);
+
+    if (l.locked ())
+    {
+      if (!find_ (sts, &id))
+        return pointer_type ();
+    }
+
+    pointer_type p (
+      access::object_factory<object_type, pointer_type>::create ());
+    pointer_traits::guard pg (p);
+
+    pointer_cache_traits::insert_guard ig (
+      pointer_cache_traits::insert (db, id, p));
+
+    object_type& obj (pointer_traits::get_ref (p));
+
+    if (l.locked ())
+    {
+      select_statement& st (sts.find_statement ());
+      ODB_POTENTIALLY_UNUSED (st);
+
+      callback (db, obj, callback_event::pre_load);
+      init (obj, sts.image (), &db);
+      load_ (sts, obj, false);
+      sts.load_delayed (0);
+      l.unlock ();
+      callback (db, obj, callback_event::post_load);
+      pointer_cache_traits::load (ig.position ());
+    }
+    else
+      sts.delay_load (id, obj, ig.position ());
+
+    ig.release ();
+    pg.release ();
+    return p;
+  }
+
+  bool access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  find (database& db, const id_type& id, object_type& obj)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    statements_type::auto_lock l (sts);
+    assert (l.locked ()) /* Must be a top-level call. */;
+
+    if (!find_ (sts, &id))
+      return false;
+
+    select_statement& st (sts.find_statement ());
+    ODB_POTENTIALLY_UNUSED (st);
+
+    reference_cache_traits::position_type pos (
+      reference_cache_traits::insert (db, id, obj));
+    reference_cache_traits::insert_guard ig (pos);
+
+    callback (db, obj, callback_event::pre_load);
+    init (obj, sts.image (), &db);
+    load_ (sts, obj, false);
+    sts.load_delayed (0);
+    l.unlock ();
+    callback (db, obj, callback_event::post_load);
+    reference_cache_traits::load (pos);
+    ig.release ();
+    return true;
+  }
+
+  bool access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  reload (database& db, object_type& obj)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    statements_type::auto_lock l (sts);
+    assert (l.locked ()) /* Must be a top-level call. */;
+
+    const id_type& id (object_traits_impl::id (obj));
+    if (!find_ (sts, &id))
+      return false;
+
+    select_statement& st (sts.find_statement ());
+    ODB_POTENTIALLY_UNUSED (st);
+
+    callback (db, obj, callback_event::pre_load);
+    init (obj, sts.image (), &db);
+    load_ (sts, obj, true);
+    sts.load_delayed (0);
+    l.unlock ();
+    callback (db, obj, callback_event::post_load);
+    return true;
+  }
+
+  bool access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  find_ (statements_type& sts,
+         const id_type* id)
+  {
+    using namespace sqlite;
+
+    id_image_type& i (sts.id_image ());
+    init (i, *id);
+
+    binding& idb (sts.id_image_binding ());
+    if (i.version != sts.id_image_version () || idb.version == 0)
+    {
+      bind (idb.bind, i);
+      sts.id_image_version (i.version);
+      idb.version++;
+    }
+
+    image_type& im (sts.image ());
+    binding& imb (sts.select_image_binding ());
+
+    if (im.version != sts.select_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, im, statement_select);
+      sts.select_image_version (im.version);
+      imb.version++;
+    }
+
+    select_statement& st (sts.find_statement ());
+
+    st.execute ();
+    auto_result ar (st);
+    select_statement::result r (st.fetch ());
+
+    if (r == select_statement::truncated)
+    {
+      if (grow (im, sts.select_image_truncated ()))
+        im.version++;
+
+      if (im.version != sts.select_image_version ())
+      {
+        bind (imb.bind, im, statement_select);
+        sts.select_image_version (im.version);
+        imb.version++;
+        st.refetch ();
+      }
+    }
+
+    return r != select_statement::no_data;
+  }
+
+  result< access::object_traits_impl< ::launcher::user_setting, id_sqlite >::object_type >
+  access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  query (database& db, const query_base_type& q)
+  {
+    using namespace sqlite;
+    using odb::details::shared;
+    using odb::details::shared_ptr;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    image_type& im (sts.image ());
+    binding& imb (sts.select_image_binding ());
+
+    if (im.version != sts.select_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, im, statement_select);
+      sts.select_image_version (im.version);
+      imb.version++;
+    }
+
+    std::string text (query_statement);
+    if (!q.empty ())
+    {
+      text += " ";
+      text += q.clause ();
+    }
+
+    q.init_parameters ();
+    shared_ptr<select_statement> st (
+      new (shared) select_statement (
+        conn,
+        text,
+        false,
+        true,
+        q.parameters_binding (),
+        imb));
+
+    st->execute ();
+
+    shared_ptr< odb::object_result_impl<object_type> > r (
+      new (shared) sqlite::object_result_impl<object_type> (
+        q, st, sts, 0));
+
+    return result<object_type> (r);
+  }
+
+  unsigned long long access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  erase_query (database& db, const query_base_type& q)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection (db));
+
+    std::string text (erase_query_statement);
+    if (!q.empty ())
+    {
+      text += ' ';
+      text += q.clause ();
+    }
+
+    q.init_parameters ();
+    delete_statement st (
+      conn,
+      text,
+      q.parameters_binding ());
+
+    return st.execute ();
+  }
 }
 
 namespace odb
@@ -1529,6 +2164,7 @@ namespace odb
         }
         case 2:
         {
+          db.execute ("DROP TABLE IF EXISTS \"user_settings\"");
           db.execute ("DROP TABLE IF EXISTS \"component_versions\"");
           db.execute ("DROP TABLE IF EXISTS \"cached_files\"");
           return false;
@@ -1554,6 +2190,9 @@ namespace odb
                       "  \"component\" INTEGER NOT NULL PRIMARY KEY,\n"
                       "  \"tag\" TEXT NOT NULL,\n"
                       "  \"installed_at\" INTEGER NOT NULL)");
+          db.execute ("CREATE TABLE \"user_settings\" (\n"
+                      "  \"key\" TEXT NOT NULL PRIMARY KEY,\n"
+                      "  \"val\" TEXT NOT NULL)");
           return false;
         }
       }

--- a/launcher/launcher/pregenerated/launcher/cache/cache-types-odb.hxx
+++ b/launcher/launcher/pregenerated/launcher/cache/cache-types-odb.hxx
@@ -119,6 +119,48 @@ namespace odb
     static void
     callback (database&, const object_type&, callback_event);
   };
+
+  // user_setting
+  //
+  template <>
+  struct class_traits< ::launcher::user_setting >
+  {
+    static const class_kind kind = class_object;
+  };
+
+  template <>
+  class access::object_traits< ::launcher::user_setting >
+  {
+    public:
+    typedef ::launcher::user_setting object_type;
+    typedef ::launcher::user_setting* pointer_type;
+    typedef odb::pointer_traits<pointer_type> pointer_traits;
+
+    static const bool polymorphic = false;
+
+    typedef ::std::string id_type;
+
+    static const bool auto_id = false;
+
+    static const bool abstract = false;
+
+    static id_type
+    id (const object_type&);
+
+    typedef
+    no_op_pointer_cache_traits<pointer_type>
+    pointer_cache_traits;
+
+    typedef
+    no_op_reference_cache_traits<object_type>
+    reference_cache_traits;
+
+    static void
+    callback (database&, object_type&, callback_event);
+
+    static void
+    callback (database&, const object_type&, callback_event);
+  };
 }
 
 #include <odb/details/buffer.hxx>
@@ -594,9 +636,188 @@ namespace odb
   {
   };
 
+  // user_setting
+  //
+  template <typename A>
+  struct query_columns< ::launcher::user_setting, id_sqlite, A >
+  {
+    // key
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    key_type_;
+
+    static const key_type_ key;
+
+    // val
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    val_type_;
+
+    static const val_type_ val;
+  };
+
+  template <typename A>
+  const typename query_columns< ::launcher::user_setting, id_sqlite, A >::key_type_
+  query_columns< ::launcher::user_setting, id_sqlite, A >::
+  key (A::table_name, "\"key\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::launcher::user_setting, id_sqlite, A >::val_type_
+  query_columns< ::launcher::user_setting, id_sqlite, A >::
+  val (A::table_name, "\"val\"", 0);
+
+  template <typename A>
+  struct pointer_query_columns< ::launcher::user_setting, id_sqlite, A >:
+    query_columns< ::launcher::user_setting, id_sqlite, A >
+  {
+  };
+
+  template <>
+  class access::object_traits_impl< ::launcher::user_setting, id_sqlite >:
+    public access::object_traits< ::launcher::user_setting >
+  {
+    public:
+    struct id_image_type
+    {
+      details::buffer id_value;
+      std::size_t id_size;
+      bool id_null;
+
+      std::size_t version;
+    };
+
+    struct image_type
+    {
+      // key_
+      //
+      details::buffer key_value;
+      std::size_t key_size;
+      bool key_null;
+
+      // val_
+      //
+      details::buffer val_value;
+      std::size_t val_size;
+      bool val_null;
+
+      std::size_t version;
+    };
+
+    struct extra_statement_cache_type;
+
+    using object_traits<object_type>::id;
+
+    static id_type
+    id (const image_type&);
+
+    static bool
+    grow (image_type&,
+          bool*);
+
+    static void
+    bind (sqlite::bind*,
+          image_type&,
+          sqlite::statement_kind);
+
+    static void
+    bind (sqlite::bind*, id_image_type&);
+
+    static bool
+    init (image_type&,
+          const object_type&,
+          sqlite::statement_kind);
+
+    static void
+    init (object_type&,
+          const image_type&,
+          database*);
+
+    static void
+    init (id_image_type&, const id_type&);
+
+    typedef sqlite::object_statements<object_type> statements_type;
+
+    typedef sqlite::query_base query_base_type;
+
+    static const std::size_t column_count = 2UL;
+    static const std::size_t id_column_count = 1UL;
+    static const std::size_t inverse_column_count = 0UL;
+    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t managed_optimistic_column_count = 0UL;
+
+    static const std::size_t separate_load_column_count = 0UL;
+    static const std::size_t separate_update_column_count = 0UL;
+
+    static const bool versioned = false;
+
+    static const char persist_statement[];
+    static const char find_statement[];
+    static const char update_statement[];
+    static const char erase_statement[];
+    static const char query_statement[];
+    static const char erase_query_statement[];
+
+    static const char table_name[];
+
+    static void
+    persist (database&, const object_type&);
+
+    static pointer_type
+    find (database&, const id_type&);
+
+    static bool
+    find (database&, const id_type&, object_type&);
+
+    static bool
+    reload (database&, object_type&);
+
+    static void
+    update (database&, const object_type&);
+
+    static void
+    erase (database&, const id_type&);
+
+    static void
+    erase (database&, const object_type&);
+
+    static result<object_type>
+    query (database&, const query_base_type&);
+
+    static unsigned long long
+    erase_query (database&, const query_base_type&);
+
+    public:
+    static bool
+    find_ (statements_type&,
+           const id_type*);
+
+    static void
+    load_ (statements_type&,
+           object_type&,
+           bool reload);
+  };
+
+  template <>
+  class access::object_traits_impl< ::launcher::user_setting, id_common >:
+    public access::object_traits_impl< ::launcher::user_setting, id_sqlite >
+  {
+  };
+
   // cached_file
   //
   // component_version
+  //
+  // user_setting
   //
 }
 

--- a/launcher/launcher/pregenerated/launcher/cache/cache-types-odb.ixx
+++ b/launcher/launcher/pregenerated/launcher/cache/cache-types-odb.ixx
@@ -63,6 +63,35 @@ namespace odb
     ODB_POTENTIALLY_UNUSED (x);
     ODB_POTENTIALLY_UNUSED (e);
   }
+
+  // user_setting
+  //
+
+  inline
+  access::object_traits< ::launcher::user_setting >::id_type
+  access::object_traits< ::launcher::user_setting >::
+  id (const object_type& o)
+  {
+    return o.key_;
+  }
+
+  inline
+  void access::object_traits< ::launcher::user_setting >::
+  callback (database& db, object_type& x, callback_event e)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (x);
+    ODB_POTENTIALLY_UNUSED (e);
+  }
+
+  inline
+  void access::object_traits< ::launcher::user_setting >::
+  callback (database& db, const object_type& x, callback_event e)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (x);
+    ODB_POTENTIALLY_UNUSED (e);
+  }
 }
 
 namespace odb
@@ -103,6 +132,28 @@ namespace odb
 
   inline
   void access::object_traits_impl< ::launcher::component_version, id_sqlite >::
+  load_ (statements_type& sts,
+         object_type& obj,
+         bool)
+  {
+    ODB_POTENTIALLY_UNUSED (sts);
+    ODB_POTENTIALLY_UNUSED (obj);
+  }
+
+  // user_setting
+  //
+
+  inline
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
+  erase (database& db, const object_type& obj)
+  {
+    callback (db, obj, callback_event::pre_erase);
+    erase (db, id (obj));
+    callback (db, obj, callback_event::post_erase);
+  }
+
+  inline
+  void access::object_traits_impl< ::launcher::user_setting, id_sqlite >::
   load_ (statements_type& sts,
          object_type& obj,
          bool)

--- a/launcher/launcher/pregenerated/launcher/launcher-options.cxx
+++ b/launcher/launcher/pregenerated/launcher/launcher-options.cxx
@@ -763,6 +763,7 @@ namespace launcher
   options ()
   : help_ (),
     version_ (),
+    wipe_settings_ (),
     build2_metadata_ (),
     path_ (),
     path_specified_ (false),
@@ -784,6 +785,7 @@ namespace launcher
            ::launcher::cli::unknown_mode arg)
   : help_ (),
     version_ (),
+    wipe_settings_ (),
     build2_metadata_ (),
     path_ (),
     path_specified_ (false),
@@ -808,6 +810,7 @@ namespace launcher
            ::launcher::cli::unknown_mode arg)
   : help_ (),
     version_ (),
+    wipe_settings_ (),
     build2_metadata_ (),
     path_ (),
     path_specified_ (false),
@@ -832,6 +835,7 @@ namespace launcher
            ::launcher::cli::unknown_mode arg)
   : help_ (),
     version_ (),
+    wipe_settings_ (),
     build2_metadata_ (),
     path_ (),
     path_specified_ (false),
@@ -858,6 +862,7 @@ namespace launcher
            ::launcher::cli::unknown_mode arg)
   : help_ (),
     version_ (),
+    wipe_settings_ (),
     build2_metadata_ (),
     path_ (),
     path_specified_ (false),
@@ -880,6 +885,7 @@ namespace launcher
            ::launcher::cli::unknown_mode arg)
   : help_ (),
     version_ (),
+    wipe_settings_ (),
     build2_metadata_ (),
     path_ (),
     path_specified_ (false),
@@ -905,6 +911,8 @@ namespace launcher
     os << "--help            Show this help message and exit." << ::std::endl;
 
     os << "--version         Show version information and exit." << ::std::endl;
+
+    os << "--wipe-settings   Clear the global settings cache." << ::std::endl;
 
     os << "--build2-metadata Print the build2 metadata and exit." << ::std::endl;
 
@@ -937,6 +945,8 @@ namespace launcher
       &::launcher::cli::thunk< options, &options::help_ >;
       _cli_options_map_["--version"] =
       &::launcher::cli::thunk< options, &options::version_ >;
+      _cli_options_map_["--wipe-settings"] =
+      &::launcher::cli::thunk< options, &options::wipe_settings_ >;
       _cli_options_map_["--build2-metadata"] =
       &::launcher::cli::thunk< options, &options::build2_metadata_ >;
       _cli_options_map_["--path"] =

--- a/launcher/launcher/pregenerated/launcher/launcher-options.hxx
+++ b/launcher/launcher/pregenerated/launcher/launcher-options.hxx
@@ -481,6 +481,9 @@ namespace launcher
     version () const;
 
     const bool&
+    wipe_settings () const;
+
+    const bool&
     build2_metadata () const;
 
     const std::string&
@@ -531,6 +534,7 @@ namespace launcher
     public:
     bool help_;
     bool version_;
+    bool wipe_settings_;
     bool build2_metadata_;
     std::string path_;
     bool path_specified_;

--- a/launcher/launcher/pregenerated/launcher/launcher-options.ixx
+++ b/launcher/launcher/pregenerated/launcher/launcher-options.ixx
@@ -294,6 +294,12 @@ namespace launcher
   }
 
   inline const bool& options::
+  wipe_settings () const
+  {
+    return this->wipe_settings_;
+  }
+
+  inline const bool& options::
   build2_metadata () const
   {
     return this->build2_metadata_;


### PR DESCRIPTION
The shift toward Steam install detection as the primary standard is a massive win for the project's long-term maintainability, but as we move from the "current directory" standard that has existed since version 0.4, we face a significant gap between our new technical direction and a decade of user habits / community tutorials (among others)