### PR TITLE
Add --force-steam-runtime option

### DIFF
--- a/launcher/launcher/launcher-steam-proton.cxx
+++ b/launcher/launcher/launcher-steam-proton.cxx
@@ -15,9 +15,9 @@ namespace launcher
   namespace bp = boost::process;
 
   proton_coordinator::
-  proton_coordinator (asio::io_context& c)
+  proton_coordinator (asio::io_context& c, bool fsr)
     : ioc_ (c),
-      manager_ (c),
+      manager_ (c, fsr),
       verbose_ (false),
       logging_ (false)
   {

--- a/launcher/launcher/launcher-steam-proton.hxx
+++ b/launcher/launcher/launcher-steam-proton.hxx
@@ -26,7 +26,7 @@ namespace launcher
     // Constructors.
     //
     explicit
-    proton_coordinator (asio::io_context& ioc);
+    proton_coordinator (asio::io_context& ioc, bool force_steam_runtime);
 
     proton_coordinator (const proton_coordinator&) = delete;
     proton_coordinator& operator= (const proton_coordinator&) = delete;

--- a/launcher/launcher/launcher.cli
+++ b/launcher/launcher/launcher.cli
@@ -50,6 +50,11 @@ namespace launcher
        multiple times."
     };
 
+    bool --force-steam-runtime
+    {
+      "Use the Steam Linux Runtime container instead of the standalone Proton."
+    };
+
     bool --no-self-update
     {
       "Skip the automatic launcher self-update check. Use this if you want to

--- a/launcher/launcher/launcher.cxx
+++ b/launcher/launcher/launcher.cxx
@@ -938,7 +938,8 @@ namespace launcher
   execute (asio::io_context& /* io */,
             const path& root,
             const string& exe,
-            const vector<string>& args)
+            const vector<string>& args,
+            bool /* force_steam_runtime */)
   {
     if (exe.empty ())
       throw runtime_error ("game binary unspecified");

--- a/launcher/launcher/launcher.cxx
+++ b/launcher/launcher/launcher.cxx
@@ -870,7 +870,8 @@ namespace launcher
   execute (asio::io_context& io,
             const path& root,
             const string& exe,
-            const vector<string>& args)
+            const vector<string>& args,
+            const bool force_steam_runtime)
   {
     if (exe.empty ())
       throw runtime_error ("game binary unspecified");
@@ -885,7 +886,7 @@ namespace launcher
                           "failed to canonicalize game binary path: " +
                             to_utf8 (bin));
 
-    proton_coordinator proton (io);
+    proton_coordinator proton (io, force_steam_runtime);
 
     if (!exists (root / "steam.exe"))
       throw runtime_error ("runtime dependency missing: steam.exe");
@@ -1188,7 +1189,12 @@ try
     io,
     [&io, &root, &opt] () -> asio::awaitable<void>
   {
-    co_await execute (io, root, opt.game_exe (), opt.game_args ());
+    co_await execute (
+        io,
+        root,
+        opt.game_exe (),
+        opt.game_args (),
+        opt.force_steam_runtime ());
 
   } (), [&io, &exec_ex] (exception_ptr ep) { exec_ex = ep; io.stop (); });
 

--- a/launcher/launcher/pregenerated/launcher/launcher-options.cxx
+++ b/launcher/launcher/pregenerated/launcher/launcher-options.cxx
@@ -771,6 +771,7 @@ namespace launcher
     game_exe_specified_ (false),
     game_args_ (),
     game_args_specified_ (false),
+    force_steam_runtime_ (),
     no_self_update_ (),
     self_update_only_ (),
     skip_launch_ (),
@@ -796,6 +797,7 @@ namespace launcher
     game_exe_specified_ (false),
     game_args_ (),
     game_args_specified_ (false),
+    force_steam_runtime_ (),
     no_self_update_ (),
     self_update_only_ (),
     skip_launch_ (),
@@ -824,6 +826,7 @@ namespace launcher
     game_exe_specified_ (false),
     game_args_ (),
     game_args_specified_ (false),
+    force_steam_runtime_ (),
     no_self_update_ (),
     self_update_only_ (),
     skip_launch_ (),
@@ -852,6 +855,7 @@ namespace launcher
     game_exe_specified_ (false),
     game_args_ (),
     game_args_specified_ (false),
+    force_steam_runtime_ (),
     no_self_update_ (),
     self_update_only_ (),
     skip_launch_ (),
@@ -882,6 +886,7 @@ namespace launcher
     game_exe_specified_ (false),
     game_args_ (),
     game_args_specified_ (false),
+    force_steam_runtime_ (),
     no_self_update_ (),
     self_update_only_ (),
     skip_launch_ (),
@@ -908,6 +913,7 @@ namespace launcher
     game_exe_specified_ (false),
     game_args_ (),
     game_args_specified_ (false),
+    force_steam_runtime_ (),
     no_self_update_ (),
     self_update_only_ (),
     skip_launch_ (),
@@ -926,29 +932,32 @@ namespace launcher
     if (p == ::launcher::cli::usage_para::text)
       os << ::std::endl;
 
-    os << "--help             Show this help message and exit." << ::std::endl;
+    os << "--help                Show this help message and exit." << ::std::endl;
 
-    os << "--version          Show version information and exit." << ::std::endl;
+    os << "--version             Show version information and exit." << ::std::endl;
 
-    os << "--build2-metadata  Print the build2 metadata and exit." << ::std::endl;
+    os << "--build2-metadata     Print the build2 metadata and exit." << ::std::endl;
 
-    os << "--prerelease       Opt-in to pre-release (beta) updates." << ::std::endl;
+    os << "--prerelease          Opt-in to pre-release (beta) updates." << ::std::endl;
 
-    os << "--jobs|-j <num>    The number of parallel download jobs to run." << ::std::endl;
+    os << "--jobs|-j <num>       The number of parallel download jobs to run." << ::std::endl;
 
-    os << "--game-exe <file>  The game executable to launch." << ::std::endl;
+    os << "--game-exe <file>     The game executable to launch." << ::std::endl;
 
-    os << "--game-args <arg>  Additional arguments to pass to the game executable." << ::std::endl;
+    os << "--game-args <arg>     Additional arguments to pass to the game executable." << ::std::endl;
 
-    os << "--no-self-update   Skip the automatic launcher self-update check." << ::std::endl;
+    os << "--force-steam-runtime Use the Steam Linux Runtime container instead of the" << ::std::endl
+       << "                      standalone Proton." << ::std::endl;
 
-    os << "--self-update-only Only check for and apply launcher updates, then exit." << ::std::endl;
+    os << "--no-self-update      Skip the automatic launcher self-update check." << ::std::endl;
 
-    os << "--skip-launch      Skip launching the game after updating/installing." << ::std::endl;
+    os << "--self-update-only    Only check for and apply launcher updates, then exit." << ::std::endl;
 
-    os << "--skip-remote      Skip all remote checks and file reconciliation." << ::std::endl;
+    os << "--skip-launch         Skip launching the game after updating/installing." << ::std::endl;
 
-    os << "--proxy <url>      Route all HTTP/HTTPS traffic through the specified proxy." << ::std::endl;
+    os << "--skip-remote         Skip all remote checks and file reconciliation." << ::std::endl;
+
+    os << "--proxy <url>         Route all HTTP/HTTPS traffic through the specified proxy." << ::std::endl;
 
     p = ::launcher::cli::usage_para::option;
 
@@ -985,6 +994,8 @@ namespace launcher
       _cli_options_map_["--game-args"] =
       &::launcher::cli::thunk< options, std::vector<std::string>, &options::game_args_,
         &options::game_args_specified_ >;
+      _cli_options_map_["--force-steam-runtime"] =
+      &::launcher::cli::thunk< options, &options::force_steam_runtime_ >;
       _cli_options_map_["--no-self-update"] =
       &::launcher::cli::thunk< options, &options::no_self_update_ >;
       _cli_options_map_["--self-update-only"] =

--- a/launcher/launcher/pregenerated/launcher/launcher-options.hxx
+++ b/launcher/launcher/pregenerated/launcher/launcher-options.hxx
@@ -505,6 +505,9 @@ namespace launcher
     game_args_specified () const;
 
     const bool&
+    force_steam_runtime () const;
+
+    const bool&
     no_self_update () const;
 
     const bool&
@@ -551,6 +554,7 @@ namespace launcher
     bool game_exe_specified_;
     std::vector<std::string> game_args_;
     bool game_args_specified_;
+    bool force_steam_runtime_;
     bool no_self_update_;
     bool self_update_only_;
     bool skip_launch_;

--- a/launcher/launcher/pregenerated/launcher/launcher-options.ixx
+++ b/launcher/launcher/pregenerated/launcher/launcher-options.ixx
@@ -342,6 +342,12 @@ namespace launcher
   }
 
   inline const bool& options::
+  force_steam_runtime () const
+  {
+    return this->force_steam_runtime_;
+  }
+
+  inline const bool& options::
   no_self_update () const
   {
     return this->no_self_update_;

--- a/launcher/launcher/steam/steam-proton.cxx
+++ b/launcher/launcher/steam/steam-proton.cxx
@@ -140,8 +140,9 @@ namespace launcher
   //
 
   proton_manager::
-  proton_manager (asio::io_context& ioc)
-    : ioc_ (ioc)
+  proton_manager (asio::io_context& ioc, bool force_steam_runtime)
+    : ioc_ (ioc),
+      force_steam_runtime_(force_steam_runtime)
   {
     launcher::log::trace_l2 (categories::steam{}, "initialized proton_manager");
   }
@@ -516,9 +517,9 @@ namespace launcher
       string b;           // Binary to run.
       vector<string> cs;  // Command strings.
 
-      if (is_steam_deck ())
+      if (is_steam_deck () || force_steam_runtime_)
       {
-        launcher::log::info (categories::steam{}, "setting up sniper runtime container for steam deck launch");
+        launcher::log::info (categories::steam{}, "setting up steam sniper runtime container");
 
         // On Deck we have to wrap everything in the sniper runtime container.
         // It's a nesting doll situation:

--- a/launcher/launcher/steam/steam-proton.cxx
+++ b/launcher/launcher/steam/steam-proton.cxx
@@ -141,8 +141,8 @@ namespace launcher
 
   proton_manager::
   proton_manager (asio::io_context& ioc, bool force_steam_runtime)
-    : ioc_ (ioc),
-      force_steam_runtime_(force_steam_runtime)
+    : force_steam_runtime_(force_steam_runtime),
+      ioc_ (ioc)
   {
     launcher::log::trace_l2 (categories::steam{}, "initialized proton_manager");
   }

--- a/launcher/launcher/steam/steam-proton.hxx
+++ b/launcher/launcher/steam/steam-proton.hxx
@@ -85,7 +85,7 @@ namespace launcher
     // Constructor.
     //
     explicit
-    proton_manager (asio::io_context& ioc);
+    proton_manager (asio::io_context& ioc, bool force_steam_runtime = false);
 
     proton_manager (const proton_manager&) = delete;
     proton_manager& operator= (const proton_manager&) = delete;
@@ -154,6 +154,10 @@ namespace launcher
     //
     static bool
     version_compare (const proton_version& a, const proton_version& b);
+
+    // Force Steam runtime container
+    //
+    bool force_steam_runtime_;
 
     // IO context reference.
     //


### PR DESCRIPTION
When trying to launch the iw4x-launcher from the terminal inside the MW2 folder (`./iw4x-launcher`), the game would open but kept freezing.

Running it through Proton alone likely skipped some necessary setup steps. After testing with the Steam Runtime (the same one used on the Steam Deck), it worked.

So I added an option to force the use of the Steam Runtime container (Sniper), and it ran perfectly :)

My setup (by `fastfetch`):
```bash
OS: Arch Linux x86_64
Kernel: Linux 6.19.8-arch1-1
WM: dwm (X11)
Terminal: tmux 3.6a
CPU: 11th Gen Intel(R) Core(TM) i7-11800H (16) @ 4.60 GHz
GPU: NVIDIA GeForce RTX 3060 Mobile / Max-Q [Discrete]
```